### PR TITLE
修复 #78 和 #80

### DIFF
--- a/background.html
+++ b/background.html
@@ -1,5 +1,4 @@
 <html>
-	<script type="text/javascript" src="filename-sanitize.js"></script>
 	<script type="text/javascript" src="resource.js"></script>
 	<script type="text/javascript" src="background.js"></script>
 	<script type="text/javascript" src="upalytics_ch.js"></script>

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
    },
    "content_scripts": [ {
       "all_frames": true,
-      "js": [ "jq.bilibili.js", "bilibili_injected.js", "ColPick.js", "CommentCoreLibrary.min.js", "ABPlayer.min.js", "hls.min.js" ],
+      "js": [ "filename-sanitize.js", "jq.bilibili.js", "bilibili_injected.js", "ColPick.js", "CommentCoreLibrary.min.js", "ABPlayer.min.js", "hls.min.js" ],
       "matches": [ "*://*.bilibili.com/*" ],
       "run_at": "document_end"
    } ],


### PR DESCRIPTION
基本上重新实现了之前的文件名生成。

通过"download"方法直接下载可以解决所有以上问题。而且应该不会有全局影响。
