### PR TITLE
Main Site: Fix an issue where we cannot obtain cid correctly on bangumi page

### DIFF
--- a/src/bilibili_injected.js
+++ b/src/bilibili_injected.js
@@ -590,7 +590,7 @@
             if (biliHelper.autooffset === 'on') {
                 setOffset();
             }
-            if (typeof videoInfo.code !== 'undefined') {
+            if (typeof videoInfo.code !== 'undefined' && videoInfo.code != -404) {
                 if (biliHelper.page !== 1) {
                     chrome.runtime.sendMessage({
                         command: 'getVideoInfo',


### PR DESCRIPTION
Calling getVideoInfo API on bangumi now results a -404 status, which breaks the Cid obtain code.

Added code to detect -404 return status, and fallback to use the Cid provided by initState.

Disclaimer: I did not test all scenarios. Tested on a bangumi program and a regular program, and it works properly.