### PR TITLE
对深色模式下的直播页面“高能榜“字体颜色的修正

### DIFF
--- a/src/js/modules/darkMode/UI/pageLive.js
+++ b/src/js/modules/darkMode/UI/pageLive.js
@@ -52,6 +52,7 @@ const LivePlayDarkModeStyle = createGlobalStyle`
     
     .link-navbar .main-ctnr .nav-logo, .link-navbar .nav-item, .shortcuts-ctnr, .room-title, .tab-list .item.active, .rank-list-box a.live-skin-main-a-text, .chat-item.danmaku-item,
     .gift-item .label, .gift-info-title, .choice-item, .announcement-cntr .content, .record-title, .live-player-ctnr, .area-list-panel .list-item, .username, .user-row,
+    .top3-name, .top3-score, .name, .score, 
     .gift-component-effect-rule, .share-addr-name, th.list-head-text {
       color: var(--dark-font-0)!important;
     }


### PR DESCRIPTION
在pull之前请确认您已经完成的阅览本项目的文档、手册或开发指导意见书 [Document](./docs/main.md)，并在编码过程中遵循了其中的约定。

请确认如下两点，如若满足我们将考虑对您的pull进行采纳。

- [x] 我已经充分阅览本项目的文档、手册或开发指导意见书，并在编码过程中遵循了其中的约定。
- [x] 我对提交的代码有充分的了解，并且已经明确标注了有关的参考来源。

最后，请描述该pull的具体作用或需要特殊说明的细节：

对深色模式中直播页面的“高能榜”部分的字体颜色进行调整，影响到的class包括 `top3-name`, `top3-score`, `name` 和 `score`，将其调整为 `dark-font-0`。